### PR TITLE
 ed25519: Add PublicKey.Equal/PrivateKey.Equal from Go 1.15 

### DIFF
--- a/batch_verify.go
+++ b/batch_verify.go
@@ -312,12 +312,12 @@ func VerifyBatch(rand io.Reader, publicKeys []PublicKey, messages, sigs [][]byte
 	}
 
 	for num >= minBatchSize {
-		var batchSize = maxBatchSize
+		batchSize := maxBatchSize
 		if num < maxBatchSize {
 			batchSize = num
 		}
 
-		var batchOk = true
+		batchOk := true
 		failBatch := func(index int) {
 			ret |= 4             // >= 1 signatures in the batch failed
 			valid[index] = false // and the failures incude signature[index]

--- a/ed25519.go
+++ b/ed25519.go
@@ -141,6 +141,15 @@ func (priv PrivateKey) Public() crypto.PublicKey {
 	return PublicKey(pub)
 }
 
+// Equal reports whether priv and x have the same value.
+func (priv PrivateKey) Equal(x crypto.PrivateKey) bool {
+	xx, ok := x.(PrivateKey)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(priv, xx)
+}
+
 // Seed returns the private key seed corresponding to priv. It is provided for
 // interoperability with RFC 8032. RFC 8032's private keys correspond to seeds
 // in this package.
@@ -177,6 +186,18 @@ func (priv PrivateKey) Sign(rand io.Reader, message []byte, opts crypto.SignerOp
 
 // PublicKey is the type of Ed25519 public keys.
 type PublicKey []byte
+
+// Any methods implemented on PublicKey might need to also be implemented on
+// PrivateKey, as the latter embeds the former and will expose its methods.
+
+// Equal reports whether pub and x have the same value.
+func (pub PublicKey) Equal(x crypto.PublicKey) bool {
+	xx, ok := x.(PublicKey)
+	if !ok {
+		return false
+	}
+	return bytes.Equal(pub, xx)
+}
 
 // Sign signs the message with privateKey and returns a signature. It will
 // panic if len(privateKey) is not PrivateKeySize.

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -182,6 +182,28 @@ func TestCryptoSignerHashed(t *testing.T) {
 	}
 }
 
+func TestEqual(t *testing.T) {
+	public, private, _ := GenerateKey(rand.Reader)
+
+	if !public.Equal(public) {
+		t.Errorf("public key is not equal to itself: %q", public)
+	}
+	if !public.Equal(crypto.Signer(private).Public()) {
+		t.Errorf("private.Public() is not Equal to public: %q", public)
+	}
+	if !private.Equal(private) {
+		t.Errorf("private key is not equal to itself: %q", private)
+	}
+
+	otherPub, otherPriv, _ := GenerateKey(rand.Reader)
+	if public.Equal(otherPub) {
+		t.Errorf("different public keys are Equal")
+	}
+	if private.Equal(otherPriv) {
+		t.Errorf("different private keys are Equal")
+	}
+}
+
 func TestGolden(t *testing.T) {
 	// sign.input.gz is a selection of test cases from
 	// https://ed25519.cr.yp.to/python/sign.input

--- a/extra/x25519/x25519_test.go
+++ b/extra/x25519/x25519_test.go
@@ -61,7 +61,7 @@ var curved25519Expected = [32]byte{
 }
 
 func TestScalarBaseMult(t *testing.T) {
-	var csk = [2][32]byte{
+	csk := [2][32]byte{
 		{255},
 	}
 

--- a/internal/modm/modm_32bit.go
+++ b/internal/modm/modm_32bit.go
@@ -57,8 +57,10 @@ const (
 	mu8 uint32 = 0x000fffff
 )
 
-type Element uint32
-type Bignum256 [9]Element
+type (
+	Element   uint32
+	Bignum256 [9]Element
+)
 
 func ltModM(a, b Element) Element {
 	return (a - b) >> 31

--- a/internal/modm/modm_64bit.go
+++ b/internal/modm/modm_64bit.go
@@ -55,8 +55,10 @@ const (
 	mu4 uint64 = 0x00000fffffffff
 )
 
-type Element uint64
-type Bignum256 [5]Element
+type (
+	Element   uint64
+	Bignum256 [5]Element
+)
 
 func ltModM(a, b Element) Element {
 	// bignum256modm_element_t lt_modm(bignum256modm_element_t a, bignum256modm_element_t b)


### PR DESCRIPTION
The implementation and test casess are lifted straight from upstream.

Part of #11